### PR TITLE
Adapt Makefile to work with Xen 4.8

### DIFF
--- a/libhvm/Makefile
+++ b/libhvm/Makefile
@@ -29,13 +29,13 @@ libxenhvm.a: $(LIBHVM_OBJS)
 
 .PHONY: install
 install: all
-	$(INSTALL_DIR) $(DESTDIR)$(LIBDIR)
-	$(INSTALL_DIR) $(DESTDIR)$(INCLUDEDIR)
-	$(INSTALL_PROG) libxenhvm.so.$(MAJOR).$(MINOR) $(DESTDIR)$(LIBDIR)
-	ln -sf libxenhvm.so.$(MAJOR).$(MINOR) $(DESTDIR)$(LIBDIR)/libxenhvm.so.$(MAJOR)
-	ln -sf libxenhvm.so.$(MAJOR) $(DESTDIR)$(LIBDIR)/libxenhvm.so
-	$(INSTALL_DATA) libxenhvm.a $(DESTDIR)$(LIBDIR)
-	$(INSTALL_DATA) xenhvm.h $(DESTDIR)$(INCLUDEDIR)
+	$(INSTALL_DIR) $(DESTDIR)$(libdir)
+	$(INSTALL_DIR) $(DESTDIR)$(includedir)
+	$(INSTALL_PROG) libxenhvm.so.$(MAJOR).$(MINOR) $(DESTDIR)$(libdir)
+	ln -sf libxenhvm.so.$(MAJOR).$(MINOR) $(DESTDIR)$(libdir)/libxenhvm.so.$(MAJOR)
+	ln -sf libxenhvm.so.$(MAJOR) $(DESTDIR)$(libdir)/libxenhvm.so
+	$(INSTALL_DATA) libxenhvm.a $(DESTDIR)$(libdir)
+	$(INSTALL_DATA) xenhvm.h $(DESTDIR)$(includedir)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Some Makefile variable names were changed from Xen 4.5 to 4.8,
and appropriate changes must be made here.